### PR TITLE
Lab1 - adapter 

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/DriverManager.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/DriverManager.java
@@ -4,24 +4,24 @@ import edu.kis.powp.jobs2d.Job2dDriver;
 import edu.kis.powp.jobs2d.LoggerDriver;
 
 /**
- * Driver manager provides means to setup the driver. It also enables other
- * components and features of the application to react on configuration changes.
+ * Driver manager provides means to setup the driver. It also enables other components and features
+ * of the application to react on configuration changes.
  */
 public class DriverManager {
 
-	private Job2dDriver currentDriver = new LoggerDriver();
+  private Job2dDriver currentDriver = new LoggerDriver();
 
-	/**
-	 * @param driver Set the driver as current.
-	 */
-	public synchronized void setCurrentDriver(Job2dDriver driver) {
-		currentDriver = driver;
-	}
+  /**
+   * @param driver Set the driver as current.
+   */
+  public synchronized void setCurrentDriver(Job2dDriver driver) {
+    currentDriver = driver;
+  }
 
-	/**
-	 * @return Current driver.
-	 */
-	public synchronized Job2dDriver getCurrentDriver() {
-		return currentDriver;
-	}
+  /**
+   * @return Current driver.
+   */
+  public synchronized Job2dDriver getCurrentDriver() {
+    return currentDriver;
+  }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/SelectDriverMenuOptionListener.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/SelectDriverMenuOptionListener.java
@@ -1,23 +1,23 @@
 package edu.kis.powp.jobs2d.drivers;
 
+import edu.kis.powp.jobs2d.Job2dDriver;
+import edu.kis.powp.jobs2d.features.DriverFeature;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import edu.kis.powp.jobs2d.Job2dDriver;
-import edu.kis.powp.jobs2d.features.DriverFeature;
-
 public class SelectDriverMenuOptionListener implements ActionListener {
-	private DriverManager driverManager;
-	private Job2dDriver driver = null;
 
-	public SelectDriverMenuOptionListener(Job2dDriver driver, DriverManager driverManager) {
-		this.driverManager = driverManager;
-		this.driver = driver;
-	}
+  private DriverManager driverManager;
+  private Job2dDriver driver = null;
 
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		driverManager.setCurrentDriver(driver);
-		DriverFeature.updateDriverInfo();
-	}
+  public SelectDriverMenuOptionListener(Job2dDriver driver, DriverManager driverManager) {
+    this.driverManager = driverManager;
+    this.driver = driver;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    driverManager.setCurrentDriver(driver);
+    DriverFeature.updateDriverInfo();
+  }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawPanelAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawPanelAdapter.java
@@ -1,18 +1,20 @@
 package edu.kis.powp.jobs2d.drivers.adapter;
 
+import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.legacy.drawer.shape.ILine;
 import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.jobs2d.Job2dDriver;
+import edu.kis.powp.jobs2d.features.DrawerFeature;
 
 /**
  * driver adapter to drawer with several bugs.
  */
-public class MyAdapter extends DrawPanelController implements Job2dDriver {
+public class DrawPanelAdapter extends DrawPanelController implements Job2dDriver {
 
   private int startX = 0, startY = 0;
 
-  public MyAdapter() {
+  public DrawPanelAdapter() {
     super();
   }
 
@@ -28,7 +30,7 @@ public class MyAdapter extends DrawPanelController implements Job2dDriver {
     line.setStartCoordinates(this.startX, this.startY);
     line.setEndCoordinates(x, y);
 
-    drawLine(line);
+    DrawerFeature.getDrawerController().drawLine(line);
     this.setPosition(x, y);
   }
 

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/Job2DToDrawPanelAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/Job2DToDrawPanelAdapter.java
@@ -10,11 +10,11 @@ import edu.kis.powp.jobs2d.features.DrawerFeature;
 /**
  * driver adapter to drawer with several bugs.
  */
-public class DrawPanelAdapter extends DrawPanelController implements Job2dDriver {
+public class Job2DToDrawPanelAdapter extends DrawPanelController implements Job2dDriver {
 
   private int startX = 0, startY = 0;
 
-  public DrawPanelAdapter() {
+  public Job2DToDrawPanelAdapter() {
     super();
   }
 

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/Job2DToDrawPanelAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/Job2DToDrawPanelAdapter.java
@@ -10,13 +10,9 @@ import edu.kis.powp.jobs2d.features.DrawerFeature;
 /**
  * driver adapter to drawer with several bugs.
  */
-public class Job2DToDrawPanelAdapter extends DrawPanelController implements Job2dDriver {
+public class Job2DToDrawPanelAdapter implements Job2dDriver {
 
   private int startX = 0, startY = 0;
-
-  public Job2DToDrawPanelAdapter() {
-    super();
-  }
 
   @Override
   public void setPosition(int x, int y) {

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
@@ -9,29 +9,30 @@ import edu.kis.powp.jobs2d.Job2dDriver;
  * driver adapter to drawer with several bugs.
  */
 public class MyAdapter extends DrawPanelController implements Job2dDriver {
-	private int startX = 0, startY = 0;
 
-	public MyAdapter() {
-		super();
-	}
+  private int startX = 0, startY = 0;
 
-	@Override
-	public void setPosition(int x, int y) {
-		this.startX = x;
-		this.startY = y;
-	}
+  public MyAdapter() {
+    super();
+  }
 
-	@Override
-	public void operateTo(int x, int y) {
-		ILine line = LineFactory.getBasicLine();
-		line.setStartCoordinates(this.startX, this.startY);
-		line.setEndCoordinates(x, y);
+  @Override
+  public void setPosition(int x, int y) {
+    this.startX = x;
+    this.startY = y;
+  }
 
-		drawLine(line);
-	}
+  @Override
+  public void operateTo(int x, int y) {
+    ILine line = LineFactory.getBasicLine();
+    line.setStartCoordinates(this.startX, this.startY);
+    line.setEndCoordinates(x, y);
 
-	@Override
-	public String toString() {
-		return "@Q!$!@$!#@$(*#@&Q(%^*#@";
-	}
+    drawLine(line);
+  }
+
+  @Override
+  public String toString() {
+    return "@Q!$!@$!#@$(*#@&Q(%^*#@";
+  }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/MyAdapter.java
@@ -29,10 +29,14 @@ public class MyAdapter extends DrawPanelController implements Job2dDriver {
     line.setEndCoordinates(x, y);
 
     drawLine(line);
+    this.setPosition(x, y);
   }
 
   @Override
   public String toString() {
-    return "@Q!$!@$!#@$(*#@&Q(%^*#@";
+    return "MyAdapter{" +
+        "startX=" + startX +
+        ", startY=" + startY +
+        '}';
   }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/events/SelectClearPanelOptionListener.java
+++ b/src/main/java/edu/kis/powp/jobs2d/events/SelectClearPanelOptionListener.java
@@ -1,13 +1,13 @@
 package edu.kis.powp.jobs2d.events;
 
+import edu.kis.powp.jobs2d.features.DrawerFeature;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import edu.kis.powp.jobs2d.features.DrawerFeature;
-
 public class SelectClearPanelOptionListener implements ActionListener {
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		DrawerFeature.getDrawerController().clearPanel();
-	}
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    DrawerFeature.getDrawerController().clearPanel();
+  }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/features/DrawerFeature.java
+++ b/src/main/java/edu/kis/powp/jobs2d/features/DrawerFeature.java
@@ -1,34 +1,35 @@
 package edu.kis.powp.jobs2d.features;
 
+import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
 import edu.kis.powp.jobs2d.events.SelectClearPanelOptionListener;
-import edu.kis.legacy.drawer.panel.DrawPanelController;
 
 public class DrawerFeature {
 
-	private static DrawPanelController drawerController;
+  private static DrawPanelController drawerController;
 
-	/**
-	 * Setup Drawer Plugin and add to application.
-	 * 
-	 * @param application Application context.
-	 */
-	public static void setupDrawerPlugin(Application application) {
-		SelectClearPanelOptionListener selectClearPanelOptionListener = new SelectClearPanelOptionListener();
+  /**
+   * Setup Drawer Plugin and add to application.
+   *
+   * @param application Application context.
+   */
+  public static void setupDrawerPlugin(Application application) {
+    SelectClearPanelOptionListener selectClearPanelOptionListener = new SelectClearPanelOptionListener();
 
-		drawerController = new DrawPanelController();
-		application.addComponentMenu(DrawPanelController.class, "Draw Panel", 0);
-		application.addComponentMenuElement(DrawPanelController.class, "Clear Panel", selectClearPanelOptionListener);
+    drawerController = new DrawPanelController();
+    application.addComponentMenu(DrawPanelController.class, "Draw Panel", 0);
+    application.addComponentMenuElement(DrawPanelController.class, "Clear Panel",
+        selectClearPanelOptionListener);
 
-		drawerController.initialize(application.getFreePanel());
-	}
+    drawerController.initialize(application.getFreePanel());
+  }
 
-	/**
-	 * Get controller of application drawing panel.
-	 * 
-	 * @return drawPanelController.
-	 */
-	public static DrawPanelController getDrawerController() {
-		return drawerController;
-	}
+  /**
+   * Get controller of application drawing panel.
+   *
+   * @return drawPanelController.
+   */
+  public static DrawPanelController getDrawerController() {
+    return drawerController;
+  }
 }

--- a/src/main/java/edu/kis/powp/jobs2d/features/DriverFeature.java
+++ b/src/main/java/edu/kis/powp/jobs2d/features/DriverFeature.java
@@ -7,39 +7,40 @@ import edu.kis.powp.jobs2d.drivers.SelectDriverMenuOptionListener;
 
 public class DriverFeature {
 
-	private static DriverManager driverManager = new DriverManager();
-	private static Application app;
+  private static DriverManager driverManager = new DriverManager();
+  private static Application app;
 
-	public static DriverManager getDriverManager() {
-		return driverManager;
-	}
+  public static DriverManager getDriverManager() {
+    return driverManager;
+  }
 
-	/**
-	 * Setup jobs2d drivers Plugin and add to application.
-	 * 
-	 * @param application Application context.
-	 */
-	public static void setupDriverPlugin(Application application) {
-		app = application;
-		app.addComponentMenu(DriverFeature.class, "Drivers");
-	}
+  /**
+   * Setup jobs2d drivers Plugin and add to application.
+   *
+   * @param application Application context.
+   */
+  public static void setupDriverPlugin(Application application) {
+    app = application;
+    app.addComponentMenu(DriverFeature.class, "Drivers");
+  }
 
-	/**
-	 * Add driver to context, create button in driver menu.
-	 * 
-	 * @param name   Button name.
-	 * @param driver Job2dDriver object.
-	 */
-	public static void addDriver(String name, Job2dDriver driver) {
-		SelectDriverMenuOptionListener listener = new SelectDriverMenuOptionListener(driver, driverManager);
-		app.addComponentMenuElement(DriverFeature.class, name, listener);
-	}
+  /**
+   * Add driver to context, create button in driver menu.
+   *
+   * @param name   Button name.
+   * @param driver Job2dDriver object.
+   */
+  public static void addDriver(String name, Job2dDriver driver) {
+    SelectDriverMenuOptionListener listener = new SelectDriverMenuOptionListener(driver,
+        driverManager);
+    app.addComponentMenuElement(DriverFeature.class, name, listener);
+  }
 
-	/**
-	 * Update driver info.
-	 */
-	public static void updateDriverInfo() {
-		app.updateInfo(driverManager.getCurrentDriver().toString());
-	}
+  /**
+   * Update driver info.
+   */
+  public static void updateDriverInfo() {
+    app.updateInfo(driverManager.getCurrentDriver().toString());
+  }
 
 }

--- a/src/test/java/edu/kis/powp/jobs2d/Job2dDriverTest.java
+++ b/src/test/java/edu/kis/powp/jobs2d/Job2dDriverTest.java
@@ -1,33 +1,35 @@
 package edu.kis.powp.jobs2d;
 
-import edu.kis.powp.jobs2d.Job2dDriver;
 import edu.kis.powp.jobs2d.magicpresets.FiguresJoe;
 
 /**
  * Plotter test.
- * 
+ *
  * @author Dominik
  */
 public class Job2dDriverTest {
-	private static Job2dDriver driver = new StubDriver();
 
-	/**
-	 * Driver test.
-	 */
-	public static void main(String[] args) {
-		FiguresJoe.figureScript1(driver);
-	}
+  private static Job2dDriver driver = new StubDriver();
 
-	private static class StubDriver implements Job2dDriver {
+  /**
+   * Driver test.
+   */
+  public static void main(String[] args) {
+    FiguresJoe.figureScript1(driver);
+  }
 
-		@Override
-		public void operateTo(int x, int y) {
-			System.out.println("Driver operateTo action...");
-		}
+  private static class StubDriver implements Job2dDriver {
 
-		@Override
-		public void setPosition(int x, int y) {
-			System.out.println("Driver setPosition action...");
-		}
-	};
+    @Override
+    public void operateTo(int x, int y) {
+      System.out.println("Driver operateTo action...");
+    }
+
+    @Override
+    public void setPosition(int x, int y) {
+      System.out.println("Driver setPosition action...");
+    }
+  }
+
+  ;
 }

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -3,7 +3,7 @@ package edu.kis.powp.jobs2d;
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
-import edu.kis.powp.jobs2d.drivers.adapter.MyAdapter;
+import edu.kis.powp.jobs2d.drivers.adapter.DrawPanelAdapter;
 import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
@@ -39,7 +39,7 @@ public class TestJobs2dPatterns {
     DriverFeature.addDriver("Logger Driver", loggerDriver);
     DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
 
-    Job2dDriver testDriver = new MyAdapter();
+    Job2dDriver testDriver = new DrawPanelAdapter();
     DriverFeature.addDriver("Buggy Simulator", testDriver);
 
     DriverFeature.updateDriverInfo();
@@ -83,19 +83,16 @@ public class TestJobs2dPatterns {
    * Launch the application.
    */
   public static void main(String[] args) {
-    EventQueue.invokeLater(new Runnable() {
-      public void run() {
-        Application app = new Application("2d jobs Visio");
-        DrawerFeature.setupDrawerPlugin(app);
-        setupDefaultDrawerVisibilityManagement(app);
+    EventQueue.invokeLater(() -> {
+      Application app = new Application("2d jobs Visio");
+      DrawerFeature.setupDrawerPlugin(app);
 
-        DriverFeature.setupDriverPlugin(app);
-        setupDrivers(app);
-        setupPresetTests(app);
-        setupLogger(app);
+      DriverFeature.setupDriverPlugin(app);
+      setupDrivers(app);
+      setupPresetTests(app);
+      setupLogger(app);
 
-        app.setVisibility(true);
-      }
+      app.setVisibility(true);
     });
   }
 

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -3,7 +3,7 @@ package edu.kis.powp.jobs2d;
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
-import edu.kis.powp.jobs2d.drivers.adapter.DrawPanelAdapter;
+import edu.kis.powp.jobs2d.drivers.adapter.Job2DToDrawPanelAdapter;
 import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
@@ -26,7 +26,8 @@ public class TestJobs2dPatterns {
     SelectTestFigureOptionListener selectTestFigureOptionListener = new SelectTestFigureOptionListener(
         DriverFeature.getDriverManager());
 
-    application.addTest("Figure Joe 1", selectTestFigureOptionListener);
+    application.addTest(SelectTestFigureOptionListener.FIGURE_JOE_1, selectTestFigureOptionListener);
+    application.addTest(SelectTestFigureOptionListener.FIGURE_JOE_2, selectTestFigureOptionListener);
   }
 
   /**
@@ -39,7 +40,7 @@ public class TestJobs2dPatterns {
     DriverFeature.addDriver("Logger Driver", loggerDriver);
     DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
 
-    Job2dDriver testDriver = new DrawPanelAdapter();
+    Job2dDriver testDriver = new Job2DToDrawPanelAdapter();
     DriverFeature.addDriver("Buggy Simulator", testDriver);
 
     DriverFeature.updateDriverInfo();

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -1,10 +1,5 @@
 package edu.kis.powp.jobs2d;
 
-import java.awt.EventQueue;
-import java.awt.event.ActionEvent;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
@@ -13,86 +8,95 @@ import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
 import edu.kis.powp.jobs2d.features.DriverFeature;
+import java.awt.EventQueue;
+import java.awt.event.ActionEvent;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TestJobs2dPatterns {
-	private final static Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
 
-	/**
-	 * Setup test concerning preset figures in context.
-	 * 
-	 * @param application Application context.
-	 */
-	private static void setupPresetTests(Application application) {
-		SelectTestFigureOptionListener selectTestFigureOptionListener = new SelectTestFigureOptionListener(
-				DriverFeature.getDriverManager());
+  private final static Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
 
-		application.addTest("Figure Joe 1", selectTestFigureOptionListener);
-	}
+  /**
+   * Setup test concerning preset figures in context.
+   *
+   * @param application Application context.
+   */
+  private static void setupPresetTests(Application application) {
+    SelectTestFigureOptionListener selectTestFigureOptionListener = new SelectTestFigureOptionListener(
+        DriverFeature.getDriverManager());
 
-	/**
-	 * Setup driver manager, and set default driver for application.
-	 * 
-	 * @param application Application context.
-	 */
-	private static void setupDrivers(Application application) {
-		Job2dDriver loggerDriver = new LoggerDriver();
-		DriverFeature.addDriver("Logger Driver", loggerDriver);
-		DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
+    application.addTest("Figure Joe 1", selectTestFigureOptionListener);
+  }
 
-		Job2dDriver testDriver = new MyAdapter();
-		DriverFeature.addDriver("Buggy Simulator", testDriver);
+  /**
+   * Setup driver manager, and set default driver for application.
+   *
+   * @param application Application context.
+   */
+  private static void setupDrivers(Application application) {
+    Job2dDriver loggerDriver = new LoggerDriver();
+    DriverFeature.addDriver("Logger Driver", loggerDriver);
+    DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
 
-		DriverFeature.updateDriverInfo();
-	}
+    Job2dDriver testDriver = new MyAdapter();
+    DriverFeature.addDriver("Buggy Simulator", testDriver);
 
-	/**
-	 * Auxiliary routines to enable using Buggy Simulator.
-	 * 
-	 * @param application Application context.
-	 */
-	private static void setupDefaultDrawerVisibilityManagement(Application application) {
-		DefaultDrawerFrame defaultDrawerWindow = DefaultDrawerFrame.getDefaultDrawerFrame();
-		application.addComponentMenuElementWithCheckBox(DrawPanelController.class, "Default Drawer Visibility",
-				new SelectChangeVisibleOptionListener(defaultDrawerWindow), true);
-		defaultDrawerWindow.setVisible(true);
-	}
+    DriverFeature.updateDriverInfo();
+  }
 
-	/**
-	 * Setup menu for adjusting logging settings.
-	 * 
-	 * @param application Application context.
-	 */
-	private static void setupLogger(Application application) {
-		application.addComponentMenu(Logger.class, "Logger", 0);
-		application.addComponentMenuElement(Logger.class, "Clear log",
-				(ActionEvent e) -> application.flushLoggerOutput());
-		application.addComponentMenuElement(Logger.class, "Fine level", (ActionEvent e) -> logger.setLevel(Level.FINE));
-		application.addComponentMenuElement(Logger.class, "Info level", (ActionEvent e) -> logger.setLevel(Level.INFO));
-		application.addComponentMenuElement(Logger.class, "Warning level",
-				(ActionEvent e) -> logger.setLevel(Level.WARNING));
-		application.addComponentMenuElement(Logger.class, "Severe level",
-				(ActionEvent e) -> logger.setLevel(Level.SEVERE));
-		application.addComponentMenuElement(Logger.class, "OFF logging", (ActionEvent e) -> logger.setLevel(Level.OFF));
-	}
+  /**
+   * Auxiliary routines to enable using Buggy Simulator.
+   *
+   * @param application Application context.
+   */
+  private static void setupDefaultDrawerVisibilityManagement(Application application) {
+    DefaultDrawerFrame defaultDrawerWindow = DefaultDrawerFrame.getDefaultDrawerFrame();
+    application.addComponentMenuElementWithCheckBox(DrawPanelController.class,
+        "Default Drawer Visibility",
+        new SelectChangeVisibleOptionListener(defaultDrawerWindow), true);
+    defaultDrawerWindow.setVisible(true);
+  }
 
-	/**
-	 * Launch the application.
-	 */
-	public static void main(String[] args) {
-		EventQueue.invokeLater(new Runnable() {
-			public void run() {
-				Application app = new Application("2d jobs Visio");
-				DrawerFeature.setupDrawerPlugin(app);
-				setupDefaultDrawerVisibilityManagement(app);
+  /**
+   * Setup menu for adjusting logging settings.
+   *
+   * @param application Application context.
+   */
+  private static void setupLogger(Application application) {
+    application.addComponentMenu(Logger.class, "Logger", 0);
+    application.addComponentMenuElement(Logger.class, "Clear log",
+        (ActionEvent e) -> application.flushLoggerOutput());
+    application.addComponentMenuElement(Logger.class, "Fine level",
+        (ActionEvent e) -> logger.setLevel(Level.FINE));
+    application.addComponentMenuElement(Logger.class, "Info level",
+        (ActionEvent e) -> logger.setLevel(Level.INFO));
+    application.addComponentMenuElement(Logger.class, "Warning level",
+        (ActionEvent e) -> logger.setLevel(Level.WARNING));
+    application.addComponentMenuElement(Logger.class, "Severe level",
+        (ActionEvent e) -> logger.setLevel(Level.SEVERE));
+    application.addComponentMenuElement(Logger.class, "OFF logging",
+        (ActionEvent e) -> logger.setLevel(Level.OFF));
+  }
 
-				DriverFeature.setupDriverPlugin(app);
-				setupDrivers(app);
-				setupPresetTests(app);
-				setupLogger(app);
+  /**
+   * Launch the application.
+   */
+  public static void main(String[] args) {
+    EventQueue.invokeLater(new Runnable() {
+      public void run() {
+        Application app = new Application("2d jobs Visio");
+        DrawerFeature.setupDrawerPlugin(app);
+        setupDefaultDrawerVisibilityManagement(app);
 
-				app.setVisibility(true);
-			}
-		});
-	}
+        DriverFeature.setupDriverPlugin(app);
+        setupDrivers(app);
+        setupPresetTests(app);
+        setupLogger(app);
+
+        app.setVisibility(true);
+      }
+    });
+  }
 
 }

--- a/src/test/java/edu/kis/powp/jobs2d/events/SelectChangeVisibleOptionListener.java
+++ b/src/test/java/edu/kis/powp/jobs2d/events/SelectChangeVisibleOptionListener.java
@@ -5,19 +5,20 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 public class SelectChangeVisibleOptionListener implements ActionListener {
-	private Window controlledWindow;
 
-	public SelectChangeVisibleOptionListener(Window controlledWindow) {
-		super();
-		this.controlledWindow = controlledWindow;
-	}
+  private Window controlledWindow;
 
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		if (controlledWindow.isVisible()) {
-			controlledWindow.setVisible(false);
-		} else {
-			controlledWindow.setVisible(true);
-		}
-	}
+  public SelectChangeVisibleOptionListener(Window controlledWindow) {
+    super();
+    this.controlledWindow = controlledWindow;
+  }
+
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    if (controlledWindow.isVisible()) {
+      controlledWindow.setVisible(false);
+    } else {
+      controlledWindow.setVisible(true);
+    }
+  }
 }

--- a/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
+++ b/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
@@ -1,21 +1,20 @@
 package edu.kis.powp.jobs2d.events;
 
+import edu.kis.powp.jobs2d.drivers.DriverManager;
+import edu.kis.powp.jobs2d.magicpresets.FiguresJoe;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import edu.kis.powp.jobs2d.drivers.DriverManager;
-import edu.kis.powp.jobs2d.magicpresets.FiguresJoe;
-
 public class SelectTestFigureOptionListener implements ActionListener {
 
-	private DriverManager driverManager;
+  private DriverManager driverManager;
 
-	public SelectTestFigureOptionListener(DriverManager driverManager) {
-		this.driverManager = driverManager;
-	}
+  public SelectTestFigureOptionListener(DriverManager driverManager) {
+    this.driverManager = driverManager;
+  }
 
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		FiguresJoe.figureScript1(driverManager.getCurrentDriver());
-	}
+  @Override
+  public void actionPerformed(ActionEvent e) {
+    FiguresJoe.figureScript1(driverManager.getCurrentDriver());
+  }
 }

--- a/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
+++ b/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
@@ -7,6 +7,9 @@ import java.awt.event.ActionListener;
 
 public class SelectTestFigureOptionListener implements ActionListener {
 
+  public static String FIGURE_JOE_1 = "Figure Joe 1";
+  public static String FIGURE_JOE_2 = "Figure Joe 2";
+
   private DriverManager driverManager;
 
   public SelectTestFigureOptionListener(DriverManager driverManager) {
@@ -15,6 +18,10 @@ public class SelectTestFigureOptionListener implements ActionListener {
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    FiguresJoe.figureScript1(driverManager.getCurrentDriver());
+    if (FIGURE_JOE_1.equals(e.getActionCommand())) {
+      FiguresJoe.figureScript1(driverManager.getCurrentDriver());
+    } else if (FIGURE_JOE_2.equals(e.getActionCommand())) {
+      FiguresJoe.figureScript2(driverManager.getCurrentDriver());
+    }
   }
 }

--- a/src/test/java/edu/kis/powp/legacy/drawer/TestDrawer.java
+++ b/src/test/java/edu/kis/powp/legacy/drawer/TestDrawer.java
@@ -7,19 +7,20 @@ import edu.kis.legacy.drawer.shape.LineFactory;
 
 /**
  * Drawer test.
- * 
+ *
  * @author Dominik
  */
 public class TestDrawer {
-	/**
-	 * Drawer test.
-	 */
-	public static void main(String[] args) {
-		DrawPanelController controller = new DrawPanelController();
-		DefaultDrawerFrame.getDefaultDrawerFrame().setVisible(true);
-		ILine line = LineFactory.getBasicLine();
-		line.setStartCoordinates(-100, -60);
-		line.setEndCoordinates(60, 130);
-		controller.drawLine(line);
-	}
+
+  /**
+   * Drawer test.
+   */
+  public static void main(String[] args) {
+    DrawPanelController controller = new DrawPanelController();
+    DefaultDrawerFrame.getDefaultDrawerFrame().setVisible(true);
+    ILine line = LineFactory.getBasicLine();
+    line.setStartCoordinates(-100, -60);
+    line.setEndCoordinates(60, 130);
+    controller.drawLine(line);
+  }
 }


### PR DESCRIPTION
3.2.5
Ze wzorca adaptera warto korzystać gdy klasa z której chcemy skorzystać jest nie kompatybilna z naszą aplikacją - tworzymy połączenie łącząc np. dwa interfejsy.