### PR TITLE
Rozwiązanie lab 1 

### DIFF
--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
@@ -8,10 +8,10 @@ import edu.kis.powp.jobs2d.Job2dDriver;
 /**
  * driver adapter to drawer with several bugs.
  */
-public class MyAdapter extends DrawPanelController implements Job2dDriver {
+public class DrawerToJobs2dAdapter extends DrawPanelController implements Job2dDriver {
 	private int startX = 0, startY = 0;
 
-	public MyAdapter() {
+	public DrawerToJobs2dAdapter() {
 		super();
 	}
 
@@ -26,6 +26,7 @@ public class MyAdapter extends DrawPanelController implements Job2dDriver {
 		ILine line = LineFactory.getBasicLine();
 		line.setStartCoordinates(this.startX, this.startY);
 		line.setEndCoordinates(x, y);
+		setPosition(x,y);
 
 		drawLine(line);
 	}

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
@@ -10,7 +10,8 @@ import edu.kis.powp.jobs2d.features.DrawerFeature;
  * driver adapter to drawer with several bugs.
  */
 public class DrawerToJobs2dAdapter extends DrawPanelController implements Job2dDriver {
-	private int startX = 0, startY = 0;
+	protected int startX = 0;
+	protected int startY = 0;
 
 	public DrawerToJobs2dAdapter() {
 		super();

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapter.java
@@ -4,6 +4,7 @@ import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.legacy.drawer.shape.ILine;
 import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.jobs2d.Job2dDriver;
+import edu.kis.powp.jobs2d.features.DrawerFeature;
 
 /**
  * driver adapter to drawer with several bugs.
@@ -27,8 +28,7 @@ public class DrawerToJobs2dAdapter extends DrawPanelController implements Job2dD
 		line.setStartCoordinates(this.startX, this.startY);
 		line.setEndCoordinates(x, y);
 		setPosition(x,y);
-
-		drawLine(line);
+		DrawerFeature.getDrawerController().drawLine(line);
 	}
 
 	@Override

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
@@ -1,0 +1,22 @@
+package edu.kis.powp.jobs2d.drivers.adapter;
+
+import edu.kis.legacy.drawer.shape.ILine;
+import edu.kis.legacy.drawer.shape.LineFactory;
+import edu.kis.powp.jobs2d.features.DrawerFeature;
+
+public class DrawerToJobs2dAdapterLineTypeChoosable extends DrawerToJobs2dAdapter{
+    ILine lineType;
+
+    DrawerToJobs2dAdapterLineTypeChoosable(ILine lineType){
+        super();
+        this.lineType=lineType;
+    }
+
+    @Override
+    public void operateTo(int x, int y) {
+        lineType.setStartCoordinates(this.startX, this.startY);
+        lineType.setEndCoordinates(x, y);
+        setPosition(x,y);
+        DrawerFeature.getDrawerController().drawLine(this.lineType);
+    }
+}

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
@@ -7,7 +7,7 @@ import edu.kis.powp.jobs2d.features.DrawerFeature;
 public class DrawerToJobs2dAdapterLineTypeChoosable extends DrawerToJobs2dAdapter{
     ILine lineType;
 
-    DrawerToJobs2dAdapterLineTypeChoosable(ILine lineType){
+    public DrawerToJobs2dAdapterLineTypeChoosable(ILine lineType){
         super();
         this.lineType=lineType;
     }

--- a/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
+++ b/src/main/java/edu/kis/powp/jobs2d/drivers/adapter/DrawerToJobs2dAdapterLineTypeChoosable.java
@@ -1,7 +1,6 @@
 package edu.kis.powp.jobs2d.drivers.adapter;
 
 import edu.kis.legacy.drawer.shape.ILine;
-import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
 
 public class DrawerToJobs2dAdapterLineTypeChoosable extends DrawerToJobs2dAdapter{

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
 import edu.kis.powp.appbase.Application;
-import edu.kis.powp.jobs2d.drivers.adapter.MyAdapter;
+import edu.kis.powp.jobs2d.drivers.adapter.DrawerToJobs2dAdapter;
 import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
@@ -39,7 +39,7 @@ public class TestJobs2dPatterns {
 		DriverFeature.addDriver("Logger Driver", loggerDriver);
 		DriverFeature.getDriverManager().setCurrentDriver(loggerDriver);
 
-		Job2dDriver testDriver = new MyAdapter();
+		Job2dDriver testDriver = new DrawerToJobs2dAdapter();
 		DriverFeature.addDriver("Buggy Simulator", testDriver);
 
 		DriverFeature.updateDriverInfo();

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -83,7 +83,6 @@ public class TestJobs2dPatterns {
 			public void run() {
 				Application app = new Application("2d jobs Visio");
 				DrawerFeature.setupDrawerPlugin(app);
-				setupDefaultDrawerVisibilityManagement(app);
 
 				DriverFeature.setupDriverPlugin(app);
 				setupDrivers(app);

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -7,8 +7,10 @@ import java.util.logging.Logger;
 
 import edu.kis.legacy.drawer.panel.DefaultDrawerFrame;
 import edu.kis.legacy.drawer.panel.DrawPanelController;
+import edu.kis.legacy.drawer.shape.LineFactory;
 import edu.kis.powp.appbase.Application;
 import edu.kis.powp.jobs2d.drivers.adapter.DrawerToJobs2dAdapter;
+import edu.kis.powp.jobs2d.drivers.adapter.DrawerToJobs2dAdapterLineTypeChoosable;
 import edu.kis.powp.jobs2d.events.SelectChangeVisibleOptionListener;
 import edu.kis.powp.jobs2d.events.SelectTestFigureOptionListener;
 import edu.kis.powp.jobs2d.features.DrawerFeature;
@@ -41,6 +43,9 @@ public class TestJobs2dPatterns {
 
 		Job2dDriver testDriver = new DrawerToJobs2dAdapter();
 		DriverFeature.addDriver("Buggy Simulator", testDriver);
+
+		DriverFeature.addDriver("Special Line Simulator",
+				new DrawerToJobs2dAdapterLineTypeChoosable(LineFactory.getSpecialLine()));
 
 		DriverFeature.updateDriverInfo();
 	}

--- a/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
+++ b/src/test/java/edu/kis/powp/jobs2d/TestJobs2dPatterns.java
@@ -23,10 +23,10 @@ public class TestJobs2dPatterns {
 	 * @param application Application context.
 	 */
 	private static void setupPresetTests(Application application) {
-		SelectTestFigureOptionListener selectTestFigureOptionListener = new SelectTestFigureOptionListener(
-				DriverFeature.getDriverManager());
-
-		application.addTest("Figure Joe 1", selectTestFigureOptionListener);
+		application.addTest("Figure Joe 1", new SelectTestFigureOptionListener(
+				DriverFeature.getDriverManager(),0));
+		application.addTest("Figure Joe 2", new SelectTestFigureOptionListener(
+				DriverFeature.getDriverManager(),1));
 	}
 
 	/**

--- a/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
+++ b/src/test/java/edu/kis/powp/jobs2d/events/SelectTestFigureOptionListener.java
@@ -8,14 +8,25 @@ import edu.kis.powp.jobs2d.magicpresets.FiguresJoe;
 
 public class SelectTestFigureOptionListener implements ActionListener {
 
-	private DriverManager driverManager;
+	private final DriverManager driverManager;
+	private final int testNo;
 
 	public SelectTestFigureOptionListener(DriverManager driverManager) {
 		this.driverManager = driverManager;
+		this.testNo = 0;
+	}
+
+	public SelectTestFigureOptionListener(DriverManager driverManager, int testNumber) {
+		this.driverManager = driverManager;
+		this.testNo = testNumber;
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		FiguresJoe.figureScript1(driverManager.getCurrentDriver());
+		if (testNo == 0) {
+			FiguresJoe.figureScript1(driverManager.getCurrentDriver());
+		} else {
+			FiguresJoe.figureScript2(driverManager.getCurrentDriver());
+		}
 	}
 }


### PR DESCRIPTION
Załączam diagram UML
![UML_POWP](https://user-images.githubusercontent.com/66173126/158682434-f0487b3d-3d6e-4e06-a78b-961bbdf676c6.jpg)
 
 Commity wykonane na lab. oznaczone są kontem innego użytkownika nie zauważyłem w pracowni, że commity są oznaczone jako kogoś innego, ale zostały wykonane przeze mnie. 
 
 3.2.5 - Adapterów używamy, aby umożliwić sobie korzystanie z funkcjonalnosci jakiegoś interfejsu który bez adaptera byłby niekompatybilny. Pozwala nam to adaptować potrzebne funkcjonalności z niekompatybilnych interfejsów (działanie można wyobrazić sobie jak użycie tzw. "przejściówki" pomiędzy wtyczką, a gniazdkiem.